### PR TITLE
add null pointer prevention in delivery report

### DIFF
--- a/src/kafka/producer/delivery_report.cr
+++ b/src/kafka/producer/delivery_report.cr
@@ -6,7 +6,7 @@ module Kafka
       # This logs the message payload that was delivered.
       def self.callback
         ->(handle : LibRdKafka::KafkaHandle, message : LibRdKafka::Message, opaque : Void*) {
-          Log.info { "Message Delivered - #{String.new(message.payload)}" }
+          Log.info { "Message Delivered - #{message.payload.null? ? "(empty message payload)" : String.new(message.payload)}" }
         }
       end
     end


### PR DESCRIPTION
fixes issue https://github.com/BT-OpenSource/crafka/issues/4

adds a nil check on the message payload before creating a new string - if is null returns a default message to be logged