### PR TITLE
Add support for gracefully stopping a consumer that uses Consumer#each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Changed
+- Raise an error when trying to use a consumer after it has been closed
 - Add `Consumer#stop` method to stop an `each` loop
 - Add crystal versions 1.15.1 and 1.16.3 to test matrix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Changed
+- Add `Consumer#stop` method to stop an `each` loop
 - Add crystal versions 1.15.1 and 1.16.3 to test matrix
 
 ### Fixed

--- a/spec/kafka/consumer_spec.cr
+++ b/spec/kafka/consumer_spec.cr
@@ -11,23 +11,21 @@ describe Kafka::Consumer do
 
   describe "#subscribe" do
     it "raises an exception when given no topics" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
-
+      consumer = create_consumer
       expect_raises(Kafka::ConsumerException, "librdkafka error - Local: Invalid argument or configuration") do
         consumer.subscribe("")
       end
     end
 
     it "raises an exception when given duplicate topics" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
-
+      consumer = create_consumer
       expect_raises(Kafka::ConsumerException, "librdkafka error - Local: Invalid argument or configuration") do
         consumer.subscribe("foo", "foo")
       end
     end
 
     it "raises an exception when called after the consumer is closed" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer = create_consumer
       consumer.close
       expect_raises(Kafka::ConsumerException, "librdkafka error - Consumer closed") do
         consumer.subscribe("foo")
@@ -37,7 +35,7 @@ describe Kafka::Consumer do
 
   describe "#poll" do
     it "raises an exception when called after the consumer is closed" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer = create_consumer
       consumer.close
       expect_raises(Kafka::ConsumerException, "librdkafka error - Consumer closed") do
         consumer.poll(250)
@@ -47,7 +45,7 @@ describe Kafka::Consumer do
 
   describe "#each" do
     it "returns when stopped" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer = create_consumer
 
       spawn do
         until consumer.running?
@@ -62,7 +60,7 @@ describe Kafka::Consumer do
     end
 
     it "raises an exception when called after the consumer is closed" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer = create_consumer
       consumer.close
       expect_raises(Kafka::ConsumerException, "librdkafka error - Consumer closed") do
         consumer.each { }
@@ -72,12 +70,12 @@ describe Kafka::Consumer do
 
   describe "#open?" do
     it "returns true after creation" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer = create_consumer
       consumer.open?.should be_true
     end
 
     it "returns false after closing" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer = create_consumer
       consumer.close
       consumer.open?.should be_false
     end
@@ -85,7 +83,7 @@ describe Kafka::Consumer do
 
   describe "#close" do
     it "does not raise an exception when called multiple times" do
-      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer = create_consumer
       2.times { consumer.close }
     end
   end

--- a/spec/kafka/consumer_spec.cr
+++ b/spec/kafka/consumer_spec.cr
@@ -25,6 +25,24 @@ describe Kafka::Consumer do
         consumer.subscribe("foo", "foo")
       end
     end
+
+    it "raises an exception when called after the consumer is closed" do
+      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer.close
+      expect_raises(Kafka::ConsumerException, "librdkafka error - Consumer closed") do
+        consumer.subscribe("foo")
+      end
+    end
+  end
+
+  describe "#poll" do
+    it "raises an exception when called after the consumer is closed" do
+      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer.close
+      expect_raises(Kafka::ConsumerException, "librdkafka error - Consumer closed") do
+        consumer.poll(250)
+      end
+    end
   end
 
   describe "#each" do
@@ -41,6 +59,34 @@ describe Kafka::Consumer do
       timeout(5.seconds) do
         consumer.each(timeout: 10) { }
       end
+    end
+
+    it "raises an exception when called after the consumer is closed" do
+      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer.close
+      expect_raises(Kafka::ConsumerException, "librdkafka error - Consumer closed") do
+        consumer.each { }
+      end
+    end
+  end
+
+  describe "#open?" do
+    it "returns true after creation" do
+      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer.open?.should be_true
+    end
+
+    it "returns false after closing" do
+      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      consumer.close
+      consumer.open?.should be_false
+    end
+  end
+
+  describe "#close" do
+    it "does not raise an exception when called multiple times" do
+      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+      2.times { consumer.close }
     end
   end
 end

--- a/spec/kafka/consumer_spec.cr
+++ b/spec/kafka/consumer_spec.cr
@@ -26,4 +26,21 @@ describe Kafka::Consumer do
       end
     end
   end
+
+  describe "#each" do
+    it "returns when stopped" do
+      consumer = Kafka::Consumer.new({"bootstrap.servers" => "localhost:9094", "group.id" => "foo", "broker.address.family" => "v4"})
+
+      spawn do
+        until consumer.running?
+          sleep(30.milliseconds)
+        end
+        consumer.stop
+      end
+
+      timeout(5.seconds) do
+        consumer.each(timeout: 10) { }
+      end
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,19 @@
 require "spec"
 require "json"
 require "../src/*"
+
+def timeout(time : Time::Span, &blk)
+  done = Channel(Nil).new
+
+  spawn do
+    blk.call
+    done.send(nil)
+  end
+
+  select
+  when done.receive
+    return
+  when timeout(time)
+    raise "Timeout"
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,6 +2,12 @@ require "spec"
 require "json"
 require "../src/*"
 
+def create_consumer
+  Kafka::Consumer.new({"bootstrap.servers"     => "localhost:9094",
+                       "group.id"              => "foo",
+                       "broker.address.family" => "v4"})
+end
+
 def timeout(time : Time::Span, &blk)
   done = Channel(Nil).new
 


### PR DESCRIPTION
Currently if the `Consumer#each` method is called it will loop indefinitely with no way of gracefully stopping it. Calling `Consumer#close` closes and destroys the kafka handle, but then causes the app to crash an "Invalid memory access" inside the `each` loop the next time it calls `poll`.

This PR adds an internal flag to keep track of whether the each loop is running, and adds a `Consumer#stop` method to stop it. This can be called from, for example, a signal handler to gracefully stop the consumer.

This PR also adds some extra safety by raising an error if an attempt is made to use the consumer after it has been closed instead of crashing with an "Invalid memory access" error.

```crystal
require "crafka"

consumer = Kafka::Consumer.new({
  "bootstrap.servers"     => "localhost:9092",
  "client.id"             => "test",
  "group.id"              => "test",
  "broker.address.family" => "v4",
})

Signal::INT.trap do
  Log.info { "Received SIGINT" }
  consumer.stop
end

Log.info { "Subscribing to topic..." }
consumer.subscribe("test-topic")

Log.info { "Starting consumer loop..." }
consumer.each do |kafka_event|
  payload = String.new(kafka_event.payload)
  Log.info { "Consumed event: #{payload}" }
end
Log.info { "Exited consumer loop" }

Log.info { "Closing consumer..." }
consumer.close

Log.info { "Bye" }
```